### PR TITLE
feat(bnd-0001): Complete Tabs Component

### DIFF
--- a/public/pages/data.html
+++ b/public/pages/data.html
@@ -1,11 +1,5 @@
 <h1>Dungeons & Data</h1>
 
 <article class="card flex-column">
-  <h2>Armour</h2>
-  <table hx-get="/data/armour-table" hx-trigger="load"></table>
-</article>
-
-<article class="card flex-column">
-  <h2>Weapons</h2>
-  <table hx-get="/data/weapon-table" hx-trigger="load"></table>
+  <div hx-get="/data/tabs" hx-trigger="load"></div>
 </article>

--- a/public/styles.css
+++ b/public/styles.css
@@ -15,4 +15,5 @@
 @import url('styles/layout.css');
 @import url('styles/popover.css');
 @import url('styles/main.css');
+@import url('styles/tabs.css');
 @import url('styles/table.css');

--- a/public/styles/tabs.css
+++ b/public/styles/tabs.css
@@ -1,0 +1,34 @@
+.tab-list {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-md);
+  justify-content: center;
+}
+
+.tab-list button {
+  border-radius: var(--squarish-radius);
+  min-width: 6rem;
+  padding: var(--spacing-sm) var(--spacing-md);
+}
+
+.tab-content {
+  width: 100%;
+}
+
+.tab-panel {
+  width: 100%;
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -1,0 +1,36 @@
+import { Armour } from '../model/armour';
+import { WeaponTableRow } from '../model/weapon';
+import { ArmourTable } from './ArmourTable';
+import { WeaponTable } from './WeaponTable';
+
+interface TabContentProps {
+  tab: string;
+  armourData?: Armour[];
+  weaponData?: WeaponTableRow[];
+  className?: string;
+}
+
+export const TabContent = ({ tab, armourData, weaponData, className = '' }: TabContentProps) => {
+  switch (tab.toLowerCase()) {
+    case 'armour':
+      return armourData ? (
+        <div class={`tab-panel ${className}`}>
+          <h2>Armour</h2>
+          <ArmourTable rows={armourData} />
+        </div>
+      ) : (
+        <div>Loading armour data...</div>
+      );
+    case 'weapons':
+      return weaponData ? (
+        <div class={`tab-panel ${className}`}>
+          <h2>Weapons</h2>
+          <WeaponTable weapons={weaponData} />
+        </div>
+      ) : (
+        <div>Loading weapon data...</div>
+      );
+    default:
+      return <div class={`tab-panel ${className}`}>Select a tab to view data</div>;
+  }
+};

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,17 +1,21 @@
 import { FormattingService } from "../services/formatting-service";
 
 interface TabsProps {
-  baseRoute: string
+  baseRoute: string;
   tabHeadings: string[];
   selectedTabHeading: string;
-  tabContent: any
+  tabContent: any;
 }
 
 const renderTabListButtons = (tabHeading: string, baseRoute: string, selected: boolean) => {
+  const safeTabName = FormattingService.convertToUriSafeString(tabHeading);
+  
   return (
     <button
-      hx-get={`${baseRoute}${FormattingService.convertToUriSafeString(tabHeading)}`}
-      class={selected ? "selected" : ""}
+      hx-get={`${baseRoute}${safeTabName}`}
+      hx-target="#tab-container"
+      hx-swap="outerHTML"
+      class={`text ${selected ? "selected" : ""}`}
       role="tab"
       aria-selected={selected ? "true" : "false"}
       aria-controls="tab-content"
@@ -19,11 +23,11 @@ const renderTabListButtons = (tabHeading: string, baseRoute: string, selected: b
       {tabHeading}
     </button>
   );
-}
+};
 
 export const Tabs = ({tabHeadings, baseRoute, selectedTabHeading, tabContent}: TabsProps) => {
   return (
-    <>
+    <div id="tab-container">
       <div class="tab-list" role="tablist">
         {tabHeadings.map(tabHeading => renderTabListButtons(tabHeading, baseRoute, selectedTabHeading === tabHeading))}
       </div>
@@ -31,6 +35,6 @@ export const Tabs = ({tabHeadings, baseRoute, selectedTabHeading, tabContent}: T
       <div id="tab-content" role="tabpanel" class="tab-content">
         {tabContent}
       </div>
-    </>
+    </div>
   );
 };

--- a/src/routes/data.ts
+++ b/src/routes/data.ts
@@ -6,6 +6,8 @@ import { convertWeaponToWeaponTableRow, WeaponTableRow } from '../model/weapon';
 import { InfoPopoverContent } from '../components/InfoPopoverContent';
 import { ArmourTable } from '../components/ArmourTable';
 import { Tabs } from '../components/Tabs';
+import { FormattingService } from '../services/formatting-service';
+import { TabContent } from '../components/TabContent';
 
 export const data = new Hono();
 
@@ -73,12 +75,72 @@ data.get('/weapon-property/:property', (context: Context) => {
   );
 });
 
-data.get('table-tabs/:tab', (context: Context) => {
-  // TODO: create tab content component
-  // TODO: fetch requested content from db and return it in tab component 
+data.get('/tabs', (context: Context) => {
+  const tabHeadings = ['Armour', 'Weapons'];
+  const selectedTabHeading = 'Armour'; // Default selected tab
+  
+  // Get the data for the initial tab view
+  const armour = armourRepository
+    .readAll()
+    .map(({ id, description, ...rest }) => ({ ...rest })) as Armour[];
+  
+  const tabContent = TabContent({ 
+    tab: selectedTabHeading, 
+    armourData: armour
+  });
+  
+  return context.html(
+    Tabs({
+      baseRoute: '/data/tabs/',
+      tabHeadings,
+      selectedTabHeading,
+      tabContent
+    })
+  );
+});
+
+data.get('/tabs/:tab', (context: Context) => {
   const tab = context.req.param('tab');
-
-  return context.html(`<p>Tab</p>`);
-
-
+  const tabName = FormattingService.toTitleCase(tab.replace(/\s+/g, ' '));
+  
+  // Get data based on selected tab
+  if (tab.toLowerCase() === 'armour') {
+    const armour = armourRepository
+      .readAll()
+      .map(({ id, description, ...rest }) => ({ ...rest })) as Armour[];
+    
+    return context.html(
+      Tabs({
+        baseRoute: '/data/tabs/',
+        tabHeadings: ['Armour', 'Weapons'],
+        selectedTabHeading: tabName,
+        tabContent: TabContent({ tab: tabName, armourData: armour })
+      })
+    );
+  } else if (tab.toLowerCase() === 'weapons') {
+    const weapons = weaponRepository
+      .readAll()
+      .map(({ id, ...rest }) =>
+        convertWeaponToWeaponTableRow({ ...rest }),
+      ) as WeaponTableRow[];
+    
+    return context.html(
+      Tabs({
+        baseRoute: '/data/tabs/',
+        tabHeadings: ['Armour', 'Weapons'],
+        selectedTabHeading: tabName,
+        tabContent: TabContent({ tab: tabName, weaponData: weapons })
+      })
+    );
+  }
+  
+  // Fallback for unknown tabs
+  return context.html(
+    Tabs({
+      baseRoute: '/data/tabs/',
+      tabHeadings: ['Armour', 'Weapons'],
+      selectedTabHeading: tabName,
+      tabContent: TabContent({ tab: tabName })
+    })
+  );
 });

--- a/src/services/formatting-service.test.ts
+++ b/src/services/formatting-service.test.ts
@@ -17,7 +17,7 @@ describe('FormattingService', () => {
   });
 
   describe('convertToUriSafeString', () => {
-    test('should return the given property if it does not contain if is a single all lowercase word', () => {
+    test('should return the given string if it is a single word all lowercase', () => {
       // Arrange
       const property = 'light';
 
@@ -39,15 +39,15 @@ describe('FormattingService', () => {
       expect(result).toBe('heavy');
     });
 
-    test('should return the given string with whitespace reaplced with hyphens', () => {
+    test('should return the given string with whitespace repalced with hyphens', () => {
       // Arrange
-      const property = 'Chain mail';
+      const property = 'Chain mail armour';
 
       // Act
       const result = FormattingService.convertToUriSafeString(property);
 
       // Assert
-      expect(result).toBe('chain-mail');
+      expect(result).toBe('chain-mail-armour');
     });
 
     test('should return "ammunition-range" given the property "ammunition (range 80/120)"', () => {

--- a/src/services/formatting-service.ts
+++ b/src/services/formatting-service.ts
@@ -9,16 +9,16 @@ export class FormattingService {
       .join(' ');
   }
 
-  static convertToUriSafeString(property: string): string {
-    const rangedPropertyMatch = property.match(/(ammunition|thrown)/i);
+  static convertToUriSafeString(str: string): string {
+    const rangedPropertyMatch = str.match(/(ammunition|thrown)/i);
     if (rangedPropertyMatch) {
       return `${rangedPropertyMatch[1]}-range`;
     }
 
-    if (property.match(/versatile/i)) {
+    if (str.match(/versatile/i)) {
       return 'versatile';
     }
 
-    return property.toLowerCase().replace(' ', '-');
+    return str.toLowerCase().replace(/\s+/g, '-');
   }
 }


### PR DESCRIPTION
# BND-0001

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/66de1134-ac8c-41d9-a015-a88ad216b525" />

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/c326611f-7478-4d5f-8460-66e40ec1fceb" />

This change completes the Tab Component, loaded to work with the Armour and Weapon tables but easily expandable.

This change also fixes a bug in the formatting service, where only the first empty space in a given string was being replaced with a hyphen.